### PR TITLE
DOC: Link to "How to make PR" tutorial as badge and in contributing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_
+|Travis|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_ |GitTutorial|_
 
 
 .. |Travis| image:: https://travis-ci.org/matplotlib/matplotlib.svg?branch=master
@@ -22,6 +22,8 @@
 .. |NUMFocus| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
 .. _NUMFocus: http://www.numfocus.org
 
+.. |GitTutorial| image:: https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?
+.. _GitTutorial: https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
 
 ##########
 Matplotlib

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -208,6 +208,8 @@ want to consider sending an email to the mailing list for more visibility.
 .. seealso::
 
   * `Git documentation <https://git-scm.com/documentation>`_
+  * `Git-Contributing to a Project <https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project>`_
+  * `Introduction to Github <https://lab.github.com/githubtraining/introduction-to-github`_
   * :ref:`development-workflow`.
   * :ref:`using-git`
 


### PR DESCRIPTION
Going by a conversation with @erinleeryan, it was suggested that a How to make a PR tutorial might be useful for new contributors. The [unidata/siphon](https://github.com/Unidata/siphon) repository addresses this by having a badge that links out to https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github. @phobson raised the concern about the tutorial not being open source, so the alternative links are 

* https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project 
* https://lab.github.com/githubtraining/introduction-to-github

My concern with the lab is that it's very oriented towards github pages & requires all sorts of permissions to turn on, but on the flip side it's probably the clearer tutorial.

The badge is [![PR Welcome](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?)](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) and was made using https://shields.io/#/